### PR TITLE
Allow override of AR and OUTDIR

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -6,14 +6,15 @@ NB_COBJS=memcpy.o memset.o memmove.o memcmp.o stpcpy.o strcmp.o strncmp.o strlen
 
 CXX ?= g++
 CC ?= gcc
+AR ?= ar
 
 # default, should be overridden:
-OUTDIR ::= .
+OUTDIR ?= .
 
 LIBBMCXX_CPPFLAGS ::= -I../include
 
 all: $(CXXOBJS) $(NB_COBJS)
-	ar r $(OUTDIR)/libbmcxx.a $(CXXOBJS) $(NB_COBJS)
+	$(AR) r $(OUTDIR)/libbmcxx.a $(CXXOBJS) $(NB_COBJS)
 
 $(CXXOBJS): %.o: %.cc
 	$(CXX) $(CXXPPFLAGS) $(LIBBMCXX_CPPFLAGS) $(CXXFLAGS) -c $< -o $@


### PR DESCRIPTION
Change assignment operator of OUTDIR to ?= and add AR, defaulting to `ar`